### PR TITLE
Add pending tests count to the stats section

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ module.exports = function (results) {
   output.stats.tests = results.numTotalTests;
   output.stats.passes = results.numPassedTests;
   output.stats.failures = results.numFailedTests;
+  output.stats.pendings = results.numPendingTests;
   output.stats.duration = Date.now() - results.startTime;
   output.stats.start = new Date(results.startTime);
   output.stats.end = new Date();


### PR DESCRIPTION
The pending(skipped) tests count is missing in the stats section, it will cause some tricky problems.

Add `output.stats.pendings`